### PR TITLE
bugfix for WAD-QC 2.06, which uses matplotlib 3

### DIFF
--- a/Catphan_wadwrapper.py
+++ b/Catphan_wadwrapper.py
@@ -61,7 +61,15 @@ except ImportError:
 
 from wad_qc.modulelibs import wadwrapper_lib
 if not 'MPLCONFIGDIR' in os.environ:
-    os.environ['MPLCONFIGDIR'] = "/tmp/.matplotlib" # if this folder already exists it must be accessible by the owner of WAD_Processor
+    import pkg_resources
+    try:
+        #only for matplotlib < 3 should we use the tmp work around, but it should be applied before importing matplotlib
+        matplotlib_version = [int(v) for v in pkg_resources.get_distribution("matplotlib").version.split('.')]
+        if matplotlib_version[0]<3:
+            os.environ['MPLCONFIGDIR'] = "/tmp/.matplotlib" # if this folder already exists it must be accessible by the owner of WAD_Processor 
+    except:
+        os.environ['MPLCONFIGDIR'] = "/tmp/.matplotlib" # if this folder already exists it must be accessible by the owner of WAD_Processor 
+
 import matplotlib
 matplotlib.use('Agg') # Force matplotlib to not use any Xwindows backend.
 


### PR DESCRIPTION
WAD-QC 2.0.6 uses matplotlib 3.x, which has a different logic for handling the font cache.